### PR TITLE
feat: customizable prompts & fix for panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ name = "clap_repl"
 path = "src/lib.rs"
 
 [dependencies]
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.4.10", features = ["derive"] }
 console = "0.15.7"
-rustyline = "11.0.0"
-shlex = "1.1.0"
+rustyline = "12.0.0"
+shlex = "1.2.0"
 
 [dev-dependencies]
 redis = "0.23.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@ impl<C: Parser> Hinter for ClapEditorHelper<C> {
 
     fn hint(&self, line: &str, _pos: usize, _ctx: &rustyline::Context<'_>) -> Option<Self::Hint> {
         let command = C::command();
-        let args = shlex::split(line).unwrap();
+        let args = shlex::split(line)?;
+
         if let [arg] = args.as_slice() {
             for c in command.get_subcommands() {
                 if let Some(x) = c.get_name().strip_prefix(arg) {
@@ -42,7 +43,6 @@ impl<C: Parser> Hinter for ClapEditorHelper<C> {
 
 impl<C: Parser> Helper for ClapEditorHelper<C> {}
 
-
 pub struct ClapEditor<C: Parser> {
     rl: Editor<ClapEditorHelper<C>, rustyline::history::FileHistory>,
     prompt: String,
@@ -55,7 +55,6 @@ impl<C: Parser> Default for ClapEditor<C> {
 }
 
 impl<C: Parser> ClapEditor<C> {
-
     fn construct(prompt: String) -> Self {
         let mut rl = Editor::<ClapEditorHelper<C>, _>::new().unwrap();
         rl.set_helper(Some(ClapEditorHelper {
@@ -65,14 +64,16 @@ impl<C: Parser> ClapEditor<C> {
             Event::KeySeq(vec![KeyEvent(KeyCode::Tab, Modifiers::NONE)]),
             Cmd::CompleteHint,
         );
-        ClapEditor { rl, prompt}
+        ClapEditor { rl, prompt }
     }
 
+    /// Creates a new `ClapEditor` with the default prompt.
     pub fn new() -> Self {
         Self::construct(style(">> ").cyan().bright().to_string())
     }
 
-    pub fn new_with_prompt(prompt: impl From<String>) -> Self {
+    /// Creates a new `ClapEditor` with the given prompt.
+    pub fn new_with_prompt(prompt: &str) -> Self {
         Self::construct(prompt.into())
     }
 
@@ -89,12 +90,25 @@ impl<C: Parser> ClapEditor<C> {
         if line.trim().is_empty() {
             return None;
         }
+
         _ = self.rl.add_history_entry(line.as_str());
-        let splited = shlex::split(&line).unwrap();
-        match C::try_parse_from(Some("".to_owned()).into_iter().chain(splited)) {
-            Ok(c) => Some(c),
-            Err(e) => {
-                e.print().unwrap();
+
+        match shlex::split(&line) {
+            Some(split) => {
+                match C::try_parse_from(std::iter::once("").chain(split.iter().map(String::as_str)))
+                {
+                    Ok(c) => Some(c),
+                    Err(e) => {
+                        e.print().unwrap();
+                        None
+                    }
+                }
+            }
+            None => {
+                println!(
+                    "{} input was not valid and could not be processed",
+                    style("error:").red().bold()
+                );
                 None
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ impl<C: Parser> Helper for ClapEditorHelper<C> {}
 
 pub struct ClapEditor<C: Parser> {
     rl: Editor<ClapEditorHelper<C>, rustyline::history::FileHistory>,
+    prompt: String,
 }
 
 impl<C: Parser> Default for ClapEditor<C> {
@@ -54,7 +55,8 @@ impl<C: Parser> Default for ClapEditor<C> {
 }
 
 impl<C: Parser> ClapEditor<C> {
-    pub fn new() -> Self {
+
+    fn construct(prompt: String) -> Self {
         let mut rl = Editor::<ClapEditorHelper<C>, _>::new().unwrap();
         rl.set_helper(Some(ClapEditorHelper {
             c_phantom: PhantomData,
@@ -63,11 +65,19 @@ impl<C: Parser> ClapEditor<C> {
             Event::KeySeq(vec![KeyEvent(KeyCode::Tab, Modifiers::NONE)]),
             Cmd::CompleteHint,
         );
-        ClapEditor { rl }
+        ClapEditor { rl, prompt}
+    }
+
+    pub fn new() -> Self {
+        Self::construct(style(">> ").cyan().bright().to_string())
+    }
+
+    pub fn new_with_prompt(prompt: impl From<String>) -> Self {
+        Self::construct(prompt.into())
     }
 
     pub fn read_command(&mut self) -> Option<C> {
-        let line = match self.rl.readline(&style(">> ").cyan().bright().to_string()) {
+        let line = match self.rl.readline(&self.prompt) {
             Ok(x) => x,
             Err(e) => match e {
                 rustyline::error::ReadlineError::Eof


### PR DESCRIPTION
Hey, thanks for this crate, I'm getting some good use out of it.

I noticed there wasn't a way to customize the prompts for the repl, so I added that as I think it brings a lot of value.

Also, there were some unwraps on the calls to "shlex.split" which caused program-crashing panics whenever a quote or backslash was typed. That is also fixed in this pr.