### PR TITLE
Expose Editor in the API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use rustyline::{
     Event, Helper, KeyCode, KeyEvent, Modifiers,
 };
 
-struct ClapEditorHelper<C: Parser> {
+pub struct ClapEditorHelper<C: Parser> {
     c_phantom: PhantomData<C>,
 }
 
@@ -75,6 +75,10 @@ impl<C: Parser> ClapEditor<C> {
     /// Creates a new `ClapEditor` with the given prompt.
     pub fn new_with_prompt(prompt: &str) -> Self {
         Self::construct(prompt.into())
+    }
+
+    pub fn get_editor(&mut self) -> &mut Editor<ClapEditorHelper<C>, rustyline::history::FileHistory> {
+        &mut self.rl
     }
 
     pub fn read_command(&mut self) -> Option<C> {


### PR DESCRIPTION
This commit makes it possible to use Editor directly. My main motivation was to provide the possibility to access [ExternalPrinter](https://docs.rs/rustyline/14.0.0/rustyline/struct.Editor.html#method.create_external_printer). This is mainly 
needed for scenarios where additional threads are spawned from the repl and start printing output. In case those threads do not use external printer the output is mixed with the input that the user might be writing. On the other hand, if external printer is used, the console is updates and if the use has written something already, this line remains intact.

Example of how this is used:
```rust
    let mut rl = ClapEditor::<ReplCommand>::new_with_prompt(">> ");
    let mut printer =
        rl.get_editor().create_external_printer().unwrap();

    let (tx, rx) = std::sync::mpsc::channel();
    thread::spawn(move|| {
        for received in rx {
            printer.print(received).unwrap()
        }
    });
   ...
```