### PR TITLE
feat: add access to ClapEditor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,10 @@ impl<C: Parser + Send + Sync + 'static> ClapEditor<C> {
         &mut self.rl
     }
 
+    pub fn set_prompt(&mut self, prompt: Box<dyn Prompt>) {
+        self.prompt = prompt;
+    }
+
     pub fn read_command(&mut self) -> ReadCommandOutput<C> {
         let line = match self.rl.read_line(&*self.prompt) {
             Ok(Signal::Success(buffer)) => buffer,


### PR DESCRIPTION
> [!NOTE]
> ~~This is a breaking change~~

As disussed in #10, this PR adds access to the ClapEditor and changes the prompt to public so it can be modified while running the loop.

Please let me know if this is not the direction you'd like to take as you mentioned having to create own loop for that but that as well would require access to the `ClapEditor` and internal objects.